### PR TITLE
Handler$hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "browserify": "^12.0.1",
     "browserify-hmr": "^0.3.1",
     "budo": "^6.1.0",
+    "cycle-restart": "^0.0.14",
     "markdown-doctest": "^0.6.0",
     "mocha": "^2.4.5",
     "uglifyify": "^3.0.1"

--- a/src/collection.js
+++ b/src/collection.js
@@ -39,11 +39,11 @@ function makeItem (component, sources, props) {
   return newItem;
 }
 
-function Collection (component, sources = {}, handlers = {}, items = [], reducers = xs.create()) {
+function Collection (component, sources = {}, handlers = {}, items = [], handler$Hash = {}, reducers = xs.create()) {
   return {
     add (additionalSources = {}) {
       const newItem = makeItem(component, {...sources, ...additionalSources});
-
+      const handler$ = handlerStreams(component, newItem, handlers);
       reducers.imitate(handlerStreams(component, newItem, handlers));
 
       return Collection(
@@ -51,16 +51,26 @@ function Collection (component, sources = {}, handlers = {}, items = [], reducer
         sources,
         handlers,
         [...items, newItem],
+        {
+          ...handler$Hash,
+          [newItem.id]: handler$
+        },
         reducers
       );
     },
 
     remove (itemForRemoval) {
+      const id = itemForRemoval && itemForRemoval.id;
+      id && handler$Hash[id] && handler$Hash[id].shamefullySendComplete();
       return Collection(
         component,
         sources,
         handlers,
         items.filter(item => item !== itemForRemoval),
+        {
+          ...handler$Hash,
+          [id]: null
+        },  
         reducers
       );
     },

--- a/src/collection.js
+++ b/src/collection.js
@@ -44,7 +44,7 @@ function Collection (component, sources = {}, handlers = {}, items = [], handler
     add (additionalSources = {}) {
       const newItem = makeItem(component, {...sources, ...additionalSources});
       const handler$ = handlerStreams(component, newItem, handlers);
-      reducers.imitate(handlerStreams(component, newItem, handlers));
+      reducers.imitate(handler$);
 
       return Collection(
         component,


### PR DESCRIPTION
I think we could take a better and less "shameful" approach if we'd use a single `action$` sink in an item instead of separate sink for each action type, and would somehow enforce that the action of type `remove` really would lead to item removal. Than it could be as simple as

```js
action$ = item.action$
  .endWhen(item.action$.filter(action => action.type === 'remove').delay(0))
```

The `.delay(0)` is needed here for the first `remove` action to be processed. But there's also an option to remove the item when it's `action$` sink completes. In that case, no separate `remove` action is needed. I find the idea of item's sink completion as a signal of this item's death quite semantic.