### PR TITLE
Collection.gather

### DIFF
--- a/examples/taskrunner/app.js
+++ b/examples/taskrunner/app.js
@@ -1,0 +1,135 @@
+import {div, span, button, input} from '@cycle/dom';
+import xs from 'xstream';
+import dropRepeats from 'xstream/extra/dropRepeats';
+import Collection from '../../src/collection';
+
+function taskView ({status, text, visible}) {
+  return (
+    div('.task', {
+        style: visible ? {} : {display: 'none'}
+      }, [
+      span('.status', status),
+      ': ',
+      span('.text', text),
+      button('.delete', 'Delete')
+    ])
+  );
+}
+
+function Task ({DOM, props, deleteComplete$, filter$}) {
+  const deleteClick$ = DOM
+    .select('.delete')
+    .events('click');
+
+  const deleteIfComplete$ = props
+    .map(({status}) => deleteComplete$.filter(() => status === 'complete'))
+    .flatten();
+
+  const delete$ = xs.merge(deleteClick$, deleteIfComplete$);
+
+  const viewUnlessFiltered  = (props, filter) =>
+    taskView({
+      ...props,
+      visible: filter(props.status)
+    });
+
+  return {
+    DOM: xs.combine(viewUnlessFiltered, props, filter$),
+    complete$: props.map(({status}) => status === 'complete').compose(dropRepeats()),
+    HTTP: props
+      .map(({id}) => delete$.mapTo({
+        url: `/tasks/${id}`,
+        method: 'DELETE',
+        type: 'application/json'
+      }))
+      .flatten()
+  };
+}
+
+function addTodoReducer (todos, text) {
+  return todos.add({text});
+}
+
+function view (tasksVtrees, tasksComplete) {
+  const tasksCount = tasksComplete.length;
+  const completeCount = tasksComplete.filter(complete => complete).length;
+
+  return (
+    div('.task-runner', [
+      input('.new-task-text'),
+      button('.add-task', 'Add task'),
+      button('.delete-complete', 'Delete complete'),
+      button('.show-all', 'Show all'),
+      button('.show-complete', 'Show complete'),
+      button('.show-running', 'Show running'),
+      `${completeCount}/${tasksCount} complete`,
+      div('.todos', tasksVtrees)
+    ])
+  );
+}
+
+export default function TaskRunner ({DOM, HTTP}) {
+  const deleteComplete$ = DOM
+    .select('.delete-complete')
+    .events('click');
+
+  const filter$ = xs.merge(
+    DOM.select('.show-all').events('click').mapTo(() => true),
+    DOM.select('.show-complete').events('click').mapTo(status => status === 'complete'),
+    DOM.select('.show-running').events('click').mapTo(status => status !== 'complete')
+  ).startWith(() => true);
+
+  const tasksState$ = HTTP.response$$
+    .flatten()
+    .map(({text}) =>
+      JSON.parse(text)
+        .map(task => ({
+          id: task.id,
+          props: task
+        }))
+    )
+    .startWith([]);
+
+  const tasks$ = Collection.gather(tasksState$, Task, {DOM, deleteComplete$, filter$});
+
+  const addTaskClick$ = DOM
+    .select('.add-task')
+    .events('click');
+
+  const newTaskText$ = DOM
+    .select('.new-task-text')
+    .events('change')
+    .map(event => event.target.value)
+    .startWith('');
+
+  const addTask$ = newTaskText$
+    .map(text => addTaskClick$.mapTo({
+      url: '/tasks',
+      method: 'POST',
+      type: 'application/json',
+      send: {text}
+    }))
+    .flatten();
+
+  const refreshList$ = xs.periodic(1000).startWith().mapTo({
+    url: '/tasks',
+    method: 'GET',
+    type: 'application/json'
+  })
+
+  const tasksVtrees$ = Collection.pluck(tasks$, 'DOM');
+  const tasksComplete$ = Collection.pluck(tasks$, 'complete$');
+  const tasksRequest$ = tasks$
+    .map(collection => collection.asArray().map(item => item.HTTP))
+    .map(sinkStreams => xs.merge(...sinkStreams))
+    .flatten();
+
+  return {
+    DOM: xs.combine(view, tasksVtrees$, tasksComplete$),
+    HTTP: xs.merge(
+      addTask$,
+      refreshList$,
+      tasksRequest$
+    )
+  };
+}

--- a/examples/taskrunner/index.js
+++ b/examples/taskrunner/index.js
@@ -1,0 +1,12 @@
+import {run} from '@cycle/xstream-run';
+import {makeDOMDriver} from '@cycle/dom';
+import {makeHTTPDriver} from '@cycle/http';
+
+var app = require('./app').default;
+
+const drivers = {
+  DOM: makeDOMDriver('.app'),
+  HTTP: makeHTTPDriver()
+};
+
+run(app, drivers);

--- a/examples/taskrunner/server.js
+++ b/examples/taskrunner/server.js
@@ -1,0 +1,63 @@
+import babelify from 'babelify';
+import bodyParser from 'body-parser';
+import browserify from 'browserify-middleware';
+import cors from 'cors';
+import express from 'express';
+import hotModuleReloading from 'browserify-hmr';
+import methodOverride from 'method-override';
+
+const app = express();
+
+app.use(bodyParser.json());
+app.use(methodOverride());
+app.use(cors());
+
+let state = {
+  _id: 0,
+  tasks : [],
+  add(props) {
+    const id = String(this._id++);
+    this.tasks = [...this.tasks, {
+      ...props,
+      id,
+      status: 'running'
+    }];
+    setTimeout(() =>
+      this.update(id, { status: 'complete' }),
+      5000
+    );
+    return this.tasks;
+  },
+  remove(id) {
+    this.tasks = this.tasks.filter(task => task.id !== id);
+    return this.tasks;
+  },
+  update(id, patch) {
+    this.tasks = this.tasks.map(task => task.id === id
+      ? { ...task, ...patch }
+      : task
+    );
+    return this.tasks;
+  }
+};
+
+app.use(express.static(process.cwd()));
+
+app.get('/bundle.js', browserify(__dirname + '/index.js', {
+  transform: babelify,
+  plugin: hotModuleReloading
+}));
+
+app.get('/tasks', (req, res) =>
+  res.send(JSON.stringify(state.tasks))
+);
+
+app.post('/tasks', ({body}, res) =>
+  res.send(JSON.stringify(state.add(body)))
+);
+
+app.delete('/tasks/:id', (req, res) => {
+  res.send(JSON.stringify(state.remove(req.params.id)));
+});
+
+app.listen(8000, () => console.log('listening on localhost:8000'));

--- a/package.json
+++ b/package.json
@@ -23,23 +23,28 @@
   },
   "dependencies": {
     "@cycle/isolate": "^1.3.2",
-    "xstream": "^4.0.1"
+    "xstream": "^4.0.3"
   },
   "devDependencies": {
-    "@cycle/xstream-run": "^1.1.0",
-    "babel-preset-es2015": "^6.1.18",
+    "@cycle/http": "^v9.0.0-rc6",
     "@cycle/dom": "^10.0.0-rc17",
+    "@cycle/xstream-run": "^1.1.0",
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-polyfill": "^6.8.0",
+    "babel-preset-es2015": "^6.1.18",
     "babelify": "^7.3.0",
+    "body-parser": "^1.15.1",
     "browserify": "^12.0.1",
+    "browserify-middleware": "^7.0.0",
     "browserify-hmr": "^0.3.1",
     "budo": "^6.1.0",
+    "cors": "^2.7.1",
     "cycle-restart": "^0.0.14",
     "express": "^4.13.4",
     "markdown-doctest": "^0.6.0",
+    "method-override": "^2.3.6",
     "mocha": "^2.4.5",
     "uglifyify": "^3.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/collection.js",
   "files": ["lib/"],
   "scripts": {
-    "start": "babel-node examples/taskrunner/server.js",
+    "start": "babel-node examples/todolist/server.js",
+    "start/taskrunner": "babel-node examples/taskrunner/server.js",
     "test": "npm run test/node && npm run test/docs",
     "test/node": "mocha --compilers js:babel-core/register",
     "test/node-auto": "mocha --compilers js:babel-core/register --watch -R Min",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/collection.js",
   "files": ["lib/"],
   "scripts": {
-    "start": "babel-node examples/todolist/server.js",
+    "start": "babel-node examples/taskrunner/server.js",
     "test": "npm run test/node && npm run test/docs",
     "test/node": "mocha --compilers js:babel-core/register",
     "test/node-auto": "mocha --compilers js:babel-core/register --watch -R Min",
@@ -38,6 +38,7 @@
     "browserify-hmr": "^0.3.1",
     "budo": "^6.1.0",
     "cycle-restart": "^0.0.14",
+    "express": "^4.13.4",
     "markdown-doctest": "^0.6.0",
     "mocha": "^2.4.5",
     "uglifyify": "^3.0.1"

--- a/src/collection.js
+++ b/src/collection.js
@@ -124,82 +124,91 @@ Collection.pluck = function pluck (collection$, sinkProperty) {
 
 // convert a stream of items' sources snapshots into a stream of collections
 Collection.gather = function gather (itemsState$ , component, sources, handlers = {}, idAttribute = 'id') {
-  const makeDestroyable = component => (sources) => {
-    const sinks = component(sources);
-    return {
-      ...sinks,
-      remove$: xs.merge(sinks.remove$ || xs.never(), sources.destroy$)
+  function makeDestroyable (component) {
+    return (sources) => {
+      const sinks = component(sources);
+      return {
+        ...sinks,
+        remove$: xs.merge(sinks.remove$ || xs.never(), sources.destroy$)
+      };
     };
-  };
+  }
+
+  // finds items not present in previous snapshot
+  function findNewItems({prevIds}, items) {
+    return {
+      prevIds: items.map(item => item[idAttribute]),
+      addedItems: items.filter(item => prevIds.indexOf(item[idAttribute]) === -1)
+    };
+  }
+
+  function compareJSON(value, nextValue) {
+    if (value === nextValue) {
+      return true;
+    }
+    try {
+      if (JSON.stringify(value) === JSON.stringify(nextValue)) {
+        return true;
+      }
+    } catch(e) {}
+    // if not equal or not serializable
+    return false;
+  }
+
+  // turn a new item into a hash of source streams, tracking all the future updates
+  function itemToSourceStreams(addedItem) {
+    const itemStateInfinite$ = itemsState$
+      .map(items =>
+        items.find(item => item[idAttribute] === addedItem[idAttribute])
+      );
+    // if an item isn't present if a new snapshot, it shall be destroyed
+    const destroy$ = itemStateInfinite$.filter(item => !item).take(1);
+    const itemState$ = itemStateInfinite$.endWhen(destroy$);
+
+    return Object.keys(addedItem)
+      .reduce((sources, key) => {
+        // skip idAttribute
+        if (key === idAttribute) {
+          return sources;
+        }
+
+        return {
+          ...sources,
+          [key]: itemState$
+            .map(state => state[key])
+            .startWith(addedItem[key])
+            // skip the snapshot if the value didn't change
+            .compose(dropRepeats(compareJSON))
+            .remember()
+        };
+      }, {
+        destroy$
+      });
+  }
+
+  function addAllItems(itemsSources) {
+    return collection =>
+      itemsSources.reduce(
+        (collection, sources) => collection.add(sources),
+        collection
+      );
+  }
+
   const collection = Collection(makeDestroyable(component), sources, {
     remove$: (collection, item) => collection.remove(item),
     ...handlers
   });
-  // each time a new item appears, it should be added to the collection
+
   const addReducers$ = itemsState$
     // get the added items at each step
-    .fold(
-      ({prevIds}, items) => ({
-        prevIds: items.map(item => item[idAttribute]),
-        addedItems: items.filter(item => prevIds.indexOf(item[idAttribute]) === -1)
-      }),
-      {
-        prevIds: [],
-        addedItems: []
-      }
-    )
+    .fold(findNewItems, {prevIds: [], addedItems: []})
     .map(({addedItems}) => addedItems)
     .filter(addedItems => addedItems.length)
-    // turn each new item into a hash of source streams, tracking all the future updates
-    .map(addedItems =>
-      addedItems.map(addedItem => {
-        const itemStateInfinite$ = itemsState$
-          .map(items =>
-            items.find(item => item[idAttribute] === addedItem[idAttribute])
-          );
-        // if an item isn't present if a new snapshot, it shall be destroyed
-        const destroy$ = itemStateInfinite$.filter(item => !item).take(1);
-        const itemState$ = itemStateInfinite$.endWhen(destroy$);
-        
-        return Object.keys(addedItem)
-          .reduce((sources, key) => {
-            if (key === idAttribute) {
-              return sources;
-            }
+    .map(addedItems => addedItems.map(itemToSourceStreams))
+    .map(addAllItems);
 
-            return {
-              ...sources,
-              [key]: itemState$
-                .map(state => state[key])
-                .startWith(addedItem[key])
-                // skip the snapshot if the value didn't change
-                .compose(dropRepeats((value, nextValue) => {
-                  if (value === nextValue) {
-                    return true;
-                  }
-                  try {
-                    if (JSON.stringify(value) === JSON.stringify(nextValue)) {
-                      return true;
-                    }
-                  } catch(e) {}
-                  // if not equal or not serializable
-                  return false;
-                }))
-                .remember()
-            };
-          }, {
-            destroy$
-          })
-      })
-    )
-    .map(itemsSources => collection =>
-      itemsSources.reduce(
-        (collection, sources) => collection.add(sources),
-        collection
-      )
-    );
   return xs.merge(addReducers$, collection.reducers)
-      .fold((collection, reducer) => reducer(collection), collection);
+    .fold((collection, reducer) => reducer(collection), collection);
 };
 
 export default Collection;

--- a/src/collection.js
+++ b/src/collection.js
@@ -8,7 +8,7 @@ function id () {
   return _id++;
 }
 
-function handlerStreams (component, item, handlers = {}) {
+function handlerStreams (item, handlers = {}) {
   const sinkStreams = Object.keys(item).map(sink => {
     if (handlers[sink] === undefined) {
       return null;
@@ -29,7 +29,7 @@ function handlerStreams (component, item, handlers = {}) {
   return xs.merge(...sinkStreams.filter(reducer => reducer !== null));
 }
 
-function makeItem (component, sources, props) {
+function makeItem (component, sources) {
   const newId = id();
 
   const newItem = isolate(component, newId.toString())(sources);
@@ -46,7 +46,7 @@ function collection(options, items = [], handler$Hash = {}) {
   return {
     add (additionalSources = {}) {
       const newItem = makeItem(component, {...sources, ...additionalSources});
-      const handler$ = handlerStreams(component, newItem, handlers);
+      const handler$ = handlerStreams(newItem, handlers);
       handler$.addListener(proxy);
 
       return collection(
@@ -123,7 +123,7 @@ Collection.pluck = function pluck (collection$, sinkProperty) {
 };
 
 // convert a stream of items' sources snapshots into a stream of collections
-Collection.gather = function gather (itemsState$ , component, sources, handlers, idAttribute = 'id') {
+Collection.gather = function gather (itemsState$ , component, sources, handlers = {}, idAttribute = 'id') {
   const makeDestroyable = component => (sources) => {
     const sinks = component(sources);
     return {

--- a/styles.css
+++ b/styles.css
@@ -41,19 +41,22 @@ html, body {
   width: 100%;
 }
 
-.todo {
+.todo, .task {
   color: black;
-
-  font-size: 2rem;
-
   background: #ddd;
-
-  height: 50px;
-
-  padding: 10px;
-
   border-radius: 3px;
-
   margin: 5px;
+}
+
+.task {
+  width: auto;
+  height: 20px;
+  padding: 2px 5px;
+}
+
+.todo {
+  font-size: 2rem;
+  padding: 10px;
+  height: 50px;
 }
 

--- a/test/gather-test.js
+++ b/test/gather-test.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import xs from 'xstream';
+import delay from 'xstream/extra/delay';
 import Collection from '../src/collection';
 
 function Widget ({props}) {
@@ -110,6 +111,55 @@ describe('Collection.gather', (done) => {
       [
         [{foo: 'bar'}],
         [{baz: 'quix'}]
+      ]
+    ];
+
+    collection$.take(expected.length).addListener({
+      next (collection) {
+        const expectedItems = expected.shift();
+        const items = collection.asArray();
+        assert.equal(items.length, expectedItems.length);
+
+        items.forEach((item, i) => {
+          const expectedItem = expectedItems[i];
+          item.state$.take(expectedItem.length).addListener({
+            next (val) {
+              assert.deepEqual(val, expectedItem.shift());
+            },
+            error (err) {done(err)},
+            complete () {}
+          });
+        });
+      },
+      error (err) {done(err)},
+      complete () {
+        done();
+      }
+    });
+  });
+});
+
+describe('Collection.gather', (done) => {
+  it('removes the items that are no more present', (done) => {
+    const itemState$ = xs.of([
+        { id: 0, props: {foo: 'bar'}},
+        { id: 1, props: {baz: 'quix'}}
+      ],
+      [
+        { id: 0, props: {foo: 'bar'}}
+      ])
+      // items should be added asynchronously for collection.reducers to work properly
+      .compose(delay());
+    const collection$ = Collection.gather(itemState$, Widget, {}, {});
+
+    const expected = [
+      [],
+      [
+        [{foo: 'bar'}],
+        [{baz: 'quix'}]
+      ],
+      [
+        [{foo: 'bar'}]
       ]
     ];
 

--- a/test/gather-test.js
+++ b/test/gather-test.js
@@ -1,0 +1,139 @@
+import assert from 'assert';
+import xs from 'xstream';
+import Collection from '../src/collection';
+
+function Widget ({props}) {
+  return {
+    state$: props
+  };
+}
+
+describe('Collection.gather', (done) => {
+  it('adds initial items', (done) => {
+    const itemState$ = xs.of([
+      { id: 0, props: {foo: 'bar'}},
+      { id: 1, props: {baz: 'quix'}}
+    ]);
+    const collection$ = Collection.gather(itemState$, Widget, {}, {});
+
+    const expected = [
+      [],
+      [
+        [{foo: 'bar'}],
+        [{baz: 'quix'}]
+      ]
+    ];
+
+    collection$.take(expected.length).addListener({
+      next (collection) {
+        const expectedItems = expected.shift();
+        const items = collection.asArray();
+        assert.equal(items.length, expectedItems.length);
+        
+        items.forEach((item, i) => {
+          const expectedItem = expectedItems[i];
+          item.state$.take(expectedItem.length).addListener({
+            next (val) {
+              assert.deepEqual(val, expectedItem.shift());
+            },
+            error (err) {done(err)},
+            complete () {}
+          });
+        });
+      },
+      error (err) {done(err)},
+      complete () {
+        done();
+      }
+    });
+  });
+});
+
+describe('Collection.gather', (done) => {
+  it('tracks item\'s state by id', (done) => {
+    const itemState$ = xs.of([
+      { id: 0, props: {foo: 'bar'}}
+    ],
+    [
+      { id: 0, props: {baz: 'quix'}}
+    ]);
+    const collection$ = Collection.gather(itemState$, Widget, {}, {});
+
+    const expected = [
+      [],
+      [
+        [{foo: 'bar'}, {baz: 'quix'}]
+      ]
+    ];
+
+    collection$.take(expected.length).addListener({
+      next (collection) {
+        const expectedItems = expected.shift();
+        const items = collection.asArray();
+        assert.equal(items.length, expectedItems.length);
+
+        items.forEach((item, i) => {
+          const expectedItem = expectedItems[i];
+          item.state$.take(expectedItem.length).addListener({
+            next (val) {
+              assert.deepEqual(val, expectedItem.shift());
+            },
+            error (err) {done(err)},
+            complete () {}
+          });
+        });
+      },
+      error (err) {done(err)},
+      complete () {
+        done();
+      }
+    });
+  });
+});
+
+describe('Collection.gather', (done) => {
+  it('adds new appearing items', (done) => {
+    const itemState$ = xs.of([
+      { id: 0, props: {foo: 'bar'}}
+    ],
+    [
+      { id: 0, props: {foo: 'bar'}},
+      { id: 1, props: {baz: 'quix'}}
+    ]);
+    const collection$ = Collection.gather(itemState$, Widget, {}, {});
+
+    const expected = [
+      [],
+      [
+        [{foo: 'bar'}]
+      ],
+      [
+        [{foo: 'bar'}],
+        [{baz: 'quix'}]
+      ]
+    ];
+
+    collection$.take(expected.length).addListener({
+      next (collection) {
+        const expectedItems = expected.shift();
+        const items = collection.asArray();
+        assert.equal(items.length, expectedItems.length);
+
+        items.forEach((item, i) => {
+          const expectedItem = expectedItems[i];
+          item.state$.take(expectedItem.length).addListener({
+            next (val) {
+              assert.deepEqual(val, expectedItem.shift());
+            },
+            error (err) {done(err)},
+            complete () {}
+          });
+        });
+      },
+      error (err) {done(err)},
+      complete () {
+        done();
+      }
+    });
+  });
+});


### PR DESCRIPTION
It's a quite common use case when a collection is built from fetched data (see https://github.com/cyclejs/collection/issues/3#issuecomment-222335503). Usually it comes in a form of items' state snapshot. `Collection.gather` takes a stream of those snapshots and turns into a stream of collections, using a set of rules:

- items are keyed by `idAttribute` ('id' by default)
- items that weren't present in the previous snapshot are added to collection
- each added item tracks it's own state, turning the sequence of each field values into a source (`dropRepeats` is applied here)
- item is removed from collection if it's no more present in a snapshot

It's some kind of an opposite to `Collection.pluck` which takes a stream of collections an turns it into a stream of sink state snapshots.

Examples may be found in https://github.com/cyclejs/collection/blob/5f36bcf72ee8130b47a3267c61d54232c23109d3/test/gather-test.js and https://github.com/cyclejs/collection/blob/5f36bcf72ee8130b47a3267c61d54232c23109d3/examples/taskrunner/app.js . `run-script start/taskrunner` for demo.