### PR TITLE
Make todo items editable

### DIFF
--- a/examples/taskrunner/app.js
+++ b/examples/taskrunner/app.js
@@ -30,11 +30,7 @@ function taskView ([{status, text}, editing]) {
 function Task ({DOM, props}) {
   const delete$ = DOM
     .select('.delete')
-    .events('click')
-    .mapTo({
-      method: 'DELETE',
-      type: 'application/json'
-    });
+    .events('click');
 
   const changeText = DOM.select('.change-text');
   const changeText$ = xs.merge(

--- a/examples/taskrunner/app.js
+++ b/examples/taskrunner/app.js
@@ -11,8 +11,8 @@ function taskView ([{status, text}, editing]) {
       input('.change-text', {
         props: {value: text, hidden: !editing},
         hook: {
-          update({elm}) {
-            if(editing) {
+          update ({elm}) {
+            if (editing) {
               elm.focus();
               elm.selectionStart = text.length;
             }
@@ -107,9 +107,9 @@ function itemRequests$ (deleteComplete$, item) {
   const request$ = xs.merge(delete$, edit$);
 
   return item.HTTP.map(base => request$.map(request => ({
-      ...base,
-      ...request
-    })))
+    ...base,
+    ...request
+  })))
     .flatten();
 }
 

--- a/examples/taskrunner/app.js
+++ b/examples/taskrunner/app.js
@@ -1,48 +1,63 @@
 import {div, span, button, input} from '@cycle/dom';
 import xs from 'xstream';
-import dropRepeats from 'xstream/extra/dropRepeats';
+import delay from 'xstream/extra/delay';
 import Collection from '../../src/collection';
 
-function taskView ({status, text, visible}) {
+function taskView ([{status, text}, editing]) {
   return (
-    div('.task', {
-      style: visible ? {} : {display: 'none'}
-    }, [
+    div('.task', [
       span('.status', status),
       ': ',
-      span('.text', text),
+      input('.change-text', {
+        props: {value: text, hidden: !editing},
+        hook: {
+          update({elm}) {
+            if(editing) {
+              elm.focus();
+              elm.selectionStart = text.length;
+            }
+          }
+        }
+      }),
+      editing
+        ? ''
+        : span('.text', text),
       button('.delete', 'Delete')
     ])
   );
 }
 
-function Task ({DOM, props, deleteComplete$, filter$}) {
-  const deleteClick$ = DOM
+function Task ({DOM, props}) {
+  const delete$ = DOM
     .select('.delete')
-    .events('click');
-
-  const deleteIfComplete$ = props
-    .map(({status}) => deleteComplete$.filter(() => status === 'complete'))
-    .flatten();
-
-  const delete$ = xs.merge(deleteClick$, deleteIfComplete$);
-
-  const viewUnlessFiltered  = ([props, filter]) =>
-    taskView({
-      ...props,
-      visible: filter(props.status)
+    .events('click')
+    .mapTo({
+      method: 'DELETE',
+      type: 'application/json'
     });
 
+  const changeText = DOM.select('.change-text');
+  const changeText$ = xs.merge(
+    changeText.events('keydown')
+      .filter(event => event.code === 'Enter'),
+    changeText.events('blur')
+  ).map(event => event.target.value);
+
+  const editing$ = xs.merge(
+    DOM.select('.text').events('click').mapTo(true),
+    changeText$.compose(delay()).mapTo(false)
+  ).startWith(false);
+
+  const edit$ = editing$.map(editing => changeText$.filter(() => editing)).flatten();
+
   return {
-    DOM: xs.combine(props, filter$).map(viewUnlessFiltered),
-    complete$: props.map(({status}) => status === 'complete').compose(dropRepeats()),
-    HTTP: props
-      .map(({id}) => delete$.mapTo({
-        url: `/tasks/${id}`,
-        method: 'DELETE',
-        type: 'application/json'
-      }))
-      .flatten()
+    DOM: xs.combine(props, editing$).map(taskView),
+    complete$: props.map(({status}) => status === 'complete'),
+    delete$,
+    edit$,
+    HTTP: props.map(({id}) => ({
+      url: `/tasks/${id}`
+    }))
   };
 }
 
@@ -64,15 +79,49 @@ function view ([tasksVtrees, tasksComplete]) {
   );
 }
 
+function showViewUnlessFiltered ([vtree, complete, filter]) {
+  return filter(complete) ? vtree : '';
+}
+
+function deleteItemIfComplete$ (deleteComplete$, itemComplete$) {
+  return itemComplete$
+    .map(complete => deleteComplete$.filter(() => complete))
+    .flatten();
+}
+
+function itemRequests$ (deleteComplete$, item) {
+  const delete$ = xs.merge(
+    item.delete$,
+    deleteItemIfComplete$(deleteComplete$, item.complete$)
+  ).mapTo({
+    method: 'DELETE',
+    type: 'application/json'
+  });
+
+  const edit$ = item.edit$.map(text => ({
+    method: 'PATCH',
+    type: 'application/json',
+    send: {text}
+  }));
+
+  const request$ = xs.merge(delete$, edit$);
+
+  return item.HTTP.map(base => request$.map(request => ({
+      ...base,
+      ...request
+    })))
+    .flatten();
+}
+
 export default function TaskRunner ({DOM, HTTP}) {
   const deleteComplete$ = DOM
     .select('.delete-complete')
     .events('click');
 
   const filter$ = xs.merge(
-    DOM.select('.show-all').events('click').mapTo(() => true),
-    DOM.select('.show-complete').events('click').mapTo(status => status === 'complete'),
-    DOM.select('.show-running').events('click').mapTo(status => status !== 'complete')
+    DOM.select('.show-all').events('click').mapTo(complete => true),
+    DOM.select('.show-complete').events('click').mapTo(complete => complete),
+    DOM.select('.show-running').events('click').mapTo(complete => !complete)
   ).startWith(() => true);
 
   const tasksState$ = HTTP.response$$
@@ -86,7 +135,7 @@ export default function TaskRunner ({DOM, HTTP}) {
     )
     .startWith([]);
 
-  const tasks$ = Collection.gather(Task, {DOM, deleteComplete$, filter$}, tasksState$);
+  const tasks$ = Collection.gather(Task, {DOM}, tasksState$);
 
   const addTaskClick$ = DOM
     .select('.add-task')
@@ -113,9 +162,14 @@ export default function TaskRunner ({DOM, HTTP}) {
     type: 'application/json'
   });
 
-  const tasksVtrees$ = Collection.pluck(tasks$, item => item.DOM);
+  const tasksVtrees$ = Collection.pluck(
+    tasks$,
+    item => xs
+      .combine(item.DOM, item.complete$, filter$)
+      .map(showViewUnlessFiltered)
+  );
   const tasksComplete$ = Collection.pluck(tasks$, item => item.complete$);
-  const tasksRequest$ = Collection.merge(tasks$, item => item.HTTP);
+  const tasksRequest$ = Collection.merge(tasks$, item => itemRequests$(deleteComplete$, item));
 
   return {
     DOM: xs.combine(tasksVtrees$, tasksComplete$).map(view),

--- a/examples/taskrunner/server.js
+++ b/examples/taskrunner/server.js
@@ -53,12 +53,16 @@ app.get('/tasks', (req, res) =>
   res.send(JSON.stringify(state.tasks))
 );
 
-app.post('/tasks', ({body}, res) =>
-  res.send(JSON.stringify(state.add(body)))
+app.post('/tasks', (req, res) =>
+  res.send(JSON.stringify(state.add(req.body)))
 );
 
 app.delete('/tasks/:id', (req, res) => {
   res.send(JSON.stringify(state.remove(req.params.id)));
+});
+
+app.patch('/tasks/:id', (req, res) => {
+  res.send(JSON.stringify(state.update(req.params.id, req.body)));
 });
 
 app.listen(8000, () => console.log('listening on localhost:8000'));

--- a/examples/todolist/app.js
+++ b/examples/todolist/app.js
@@ -2,17 +2,30 @@ import {div, span, button, input} from '@cycle/dom';
 import xs from 'xstream';
 import Collection from '../../src/collection';
 
-function todoView (complete, text) {
+function todoView ([complete, editing, text]) {
   return (
     div('.todo', [
       input('.complete', {attrs: {type: 'checkbox', checked: complete}}),
-      span('.text', {style: {'text-decoration': complete ? 'line-through' : 'initial'}}, text),
+      input('.change-text', {
+        props: {value: text, hidden: !editing},
+        hook: {
+          update({elm}) {
+            if(editing) {
+              elm.focus();
+              elm.selectionStart = text.length;
+            }
+          }
+        }
+      }),
+      editing
+        ? ''
+        : span('.text', {style: {'text-decoration': complete ? 'line-through' : 'initial'}}, text),
       button('.remove', 'Remove')
     ])
   );
 }
 
-function Todo ({DOM, text}) {
+function Todo ({DOM, text$}) {
   const remove$ = DOM
     .select('.remove')
     .events('click');
@@ -23,8 +36,25 @@ function Todo ({DOM, text}) {
     .map(event => event.target.checked)
     .startWith(false);
 
+  const changeText = DOM.select('.change-text');
+  const changeText$ = xs.merge(
+    changeText.events('keydown')
+      .filter(event => event.code === 'Enter'),
+    changeText.events('blur')
+  ).map(event => event.target.value);
+
+
+  const editing$ = xs.merge(
+    DOM.select('.text').events('click').mapTo(true),
+    changeText$.mapTo(false)
+  ).startWith(false);
+
   return {
-    DOM: complete$.map(complete => todoView(complete, text)),
+    DOM: xs.combine(
+      complete$,
+      editing$,
+      xs.merge(text$, changeText$)
+    ).map(todoView),
 
     remove$,
 
@@ -59,8 +89,8 @@ function showViewUnlessFiltered ([vtree, complete, filter]) {
 }
 
 function removeItemIfComplete$ (removeComplete$, itemComplete$) {
-  return removeComplete$
-    .mapTo(itemComplete$.filter(complete => complete))
+  return itemComplete$
+    .map(complete => removeComplete$.filter(() => complete))
     .flatten();
 }
 
@@ -80,7 +110,7 @@ export default function TodoList ({DOM}) {
     .startWith('');
 
   const addTodo$ = newTodoText$
-    .map(text => addTodoClick$.mapTo({text}))
+    .map(text => addTodoClick$.mapTo({text$: xs.of(text)}))
     .flatten();
 
   const todos$ = Collection(

--- a/examples/todolist/app.js
+++ b/examples/todolist/app.js
@@ -9,8 +9,8 @@ function todoView ([complete, editing, text]) {
       input('.change-text', {
         props: {value: text, hidden: !editing},
         hook: {
-          update({elm}) {
-            if(editing) {
+          update ({elm}) {
+            if (editing) {
               elm.focus();
               elm.selectionStart = text.length;
             }
@@ -42,7 +42,6 @@ function Todo ({DOM, text$}) {
       .filter(event => event.code === 'Enter'),
     changeText.events('blur')
   ).map(event => event.target.value);
-
 
   const editing$ = xs.merge(
     DOM.select('.text').events('click').mapTo(true),

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "dependencies": {
     "@cycle/isolate": "^1.4.0",
-    "xstream": "^5.0.6"
+    "xstream": "^5.1.0"
   },
   "devDependencies": {
-    "@cycle/dom": "10.0.0-rc34",
-    "@cycle/http": "^9.0.0-rc9",
-    "@cycle/xstream-run": "^3.0.1",
+    "@cycle/dom": "^10.0.4",
+    "@cycle/http": "^9.0.2",
+    "@cycle/xstream-run": "^3.0.3",
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",

--- a/styles.css
+++ b/styles.css
@@ -60,3 +60,6 @@ html, body {
   height: 50px;
 }
 
+.todo .change-text{
+  font-size: 1.7rem;
+}


### PR DESCRIPTION
Todo item's name now can be edited on click. Changes similar to the ones in #17 are made to task runner example.

Also, a bug is fixed: after clicking 'remove complete' ones, item's completion led to immediate removal.