### PR TITLE
Fix Unified support

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -34,7 +34,7 @@ function makeCollection () {
       add (additionalSources = {}) {
         const newItem = makeItem(component, {...sources, ...additionalSources});
         const selectedSink = removeSelector(newItem) || xs.empty();
-        const removeSink = adapt(xs.fromObservable(selectedSink));
+        const removeSink = xs.fromObservable(selectedSink);
         newItem._remove$ = removeSink.take(1).mapTo(newItem);
 
         return collection(
@@ -58,7 +58,7 @@ function makeCollection () {
 
   function Collection (component, sources = {}, sourceAdd$ = xs.empty(), removeSelector = noop) {
     const removeProxy$ = xs.create();
-    const add$ = adapt(xs.fromObservable(sourceAdd$));
+    const add$ = xs.fromObservable(sourceAdd$);
     const addReducer$ = add$.map(sourcesList => collection => {
       if (Array.isArray(sourcesList)) {
         // multiple items
@@ -79,7 +79,7 @@ function makeCollection () {
     const remove$ = Collection.merge(collection$, item => item._remove$, true);
     removeProxy$.imitate(remove$);
 
-    return adapt(xs.fromObservable(collection$));
+    return adapt(collection$);
   }
 
   Collection.pluck = function pluck (sourceCollection$, pluckSelector) {
@@ -89,7 +89,7 @@ function makeCollection () {
       const key = item._id;
 
       if (sinks[key] === undefined) {
-        const selectedSink = adapt(xs.fromObservable(pluckSelector(item)));
+        const selectedSink = xs.fromObservable(pluckSelector(item));
         const sink = selectedSink.map(x =>
           isVtree(x) && x.key == null ? {...x, key} : x
         );
@@ -99,13 +99,13 @@ function makeCollection () {
       return sinks[key];
     }
 
-    const collection$ = adapt(xs.fromObservable(sourceCollection$));
+    const collection$ = xs.fromObservable(sourceCollection$);
     const outputCollection$ = collection$
       .map(items => items.map(item => sink$(item)))
       .map(sinkStreams => xs.combine(...sinkStreams))
       .flatten()
       .startWith([]);
-    return adapt(xs.fromObservable(outputCollection$));
+    return adapt(outputCollection$);
   };
 
   Collection.merge = function merge (sourceCollection$, mergeSelector, internal = false) {
@@ -115,7 +115,7 @@ function makeCollection () {
       const key = item._id;
 
       if (sinks[key] === undefined) {
-        const selectedSink = adapt(xs.fromObservable(mergeSelector(item)));
+        const selectedSink = xs.fromObservable(mergeSelector(item));
         const sink = selectedSink.map(x =>
           isVtree(x) && x.key == null ? {...x, key} : x
         );
@@ -126,14 +126,14 @@ function makeCollection () {
       return sinks[key];
     }
 
-    const collection$ = adapt(xs.fromObservable(sourceCollection$));
+    const collection$ = xs.fromObservable(sourceCollection$);
     const outputCollection$ = collection$
       .map(items => items.map(item => sink$(item)))
       .map(sinkStreams => xs.merge(...sinkStreams))
       .flatten();
     return internal
       ? outputCollection$
-      : adapt(xs.fromObservable(outputCollection$));
+      : adapt(outputCollection$);
   };
 
   // convert a stream of items' sources snapshots into a stream of collections
@@ -194,14 +194,14 @@ function makeCollection () {
 
           return {
             ...sources,
-            [sourceKey]: adapt(xs.fromObservable(stream$))
+            [sourceKey]: adapt(stream$)
           };
         }, {
           _destroy$
         });
     }
 
-    const items$ = adapt(xs.fromObservable(sourceItems$));
+    const items$ = xs.fromObservable(sourceItems$);
     const itemsState$ = items$.remember();
 
     const add$ = itemsState$

--- a/test/collection-diversity-test.js
+++ b/test/collection-diversity-test.js
@@ -1,7 +1,8 @@
-/* globals describe, it */
+/* globals describe, it, beforeEach, afterEach */
 import * as assert from 'assert';
 import {Observable as O} from 'rxjs';
 import {makeCollection} from '../src/collection';
+import {setAdapt} from '@cycle/run/lib/adapt';
 
 const Collection = makeCollection();
 
@@ -12,6 +13,20 @@ function Widget ({props$}) {
 }
 
 describe('Collection with different stream libs', () => {
+  beforeEach(function () {
+    setAdapt(O.from);
+  });
+
+  afterEach(function () {
+    setAdapt(x => x);
+  });
+
+  it('should return adapted stream', (done) => {
+    const collection$ = Collection(Widget, {});
+    assert.equal(typeof collection$.let, 'function');
+    done();
+  });
+
   it('takes an object of sources to pass to each item', (done) => {
     const props$ = O.empty();
 

--- a/test/gather-diversity-test.js
+++ b/test/gather-diversity-test.js
@@ -1,7 +1,8 @@
-/* globals describe, it */
+/* globals describe, it, beforeEach, afterEach */
 import * as assert from 'assert';
 import {Observable as O} from 'rxjs';
 import {makeCollection} from '../src/collection';
+import {setAdapt} from '@cycle/run/lib/adapt';
 
 const Collection = makeCollection();
 
@@ -12,6 +13,20 @@ function Widget ({props}) {
 }
 
 describe('Collection.gather with different stream libs', () => {
+  beforeEach(function () {
+    setAdapt(O.from);
+  });
+
+  afterEach(function () {
+    setAdapt(x => x);
+  });
+
+  it('should return adapted stream', (done) => {
+    const collection$ = Collection.gather(Widget, {}, O.of({ props: 'foo' }));
+    assert.equal(typeof collection$.let, 'function');
+    done();
+  });
+
   it('adds initial items', (done) => {
     const itemState$ = O.of([
       {id: 0, props: {foo: 'bar'}},

--- a/test/merge-diversity-test.js
+++ b/test/merge-diversity-test.js
@@ -1,7 +1,8 @@
-/* globals describe, it */
+/* globals describe, it, beforeEach, afterEach */
 import * as assert from 'assert';
 import {Observable as O} from 'rxjs';
 import {makeCollection} from '../src/collection';
+import {setAdapt} from '@cycle/run/lib/adapt';
 
 const Collection = makeCollection();
 
@@ -12,6 +13,21 @@ function Widget ({props$}) {
 }
 
 describe('Collection.merge with different stream libs', () => {
+  beforeEach(function () {
+    setAdapt(O.from);
+  });
+
+  afterEach(function () {
+    setAdapt(x => x);
+  });
+
+  it('should return adapted stream', (done) => {
+    const collection$ = Collection(Widget, {});
+    const actions$ = Collection.merge(collection$, item => item.action$);
+    assert.equal(typeof actions$.let, 'function');
+    done();
+  });
+
   it('handles adding items', (done) => {
     const props$ = O.of({foo: 'bar'});
 

--- a/test/pluck-diversity-test.js
+++ b/test/pluck-diversity-test.js
@@ -1,7 +1,8 @@
-/* globals describe, it */
+/* globals describe, it, beforeEach, afterEach */
 import * as assert from 'assert';
 import {Observable as O} from 'rxjs';
 import {makeCollection} from '../src/collection';
+import {setAdapt} from '@cycle/run/lib/adapt';
 
 const Collection = makeCollection();
 
@@ -12,6 +13,21 @@ function Widget ({props$}) {
 }
 
 describe('Collection.pluck with different stream libs', () => {
+  beforeEach(function () {
+    setAdapt(O.from);
+  });
+
+  afterEach(function () {
+    setAdapt(x => x);
+  });
+
+  it('should return adapted stream', (done) => {
+    const collection$ = Collection(Widget, {});
+    const states$ = Collection.pluck(collection$, item => item.state$);
+    assert.equal(typeof states$.let, 'function');
+    done();
+  });
+
   it('handles adding items', (done) => {
     const props$ = O.never().startWith({foo: 'bar'});
 


### PR DESCRIPTION
Previously the test passes because `take` and `subscribe` is a valid `xstream` methods, hence the test passes.

We need to also test the stream type to make sure it's really adapted.

Also the adapt function is fixed to only be used before returning streams out and `xs.fromObservable` is always used to convert streams coming in